### PR TITLE
debug: log the constraint-solver directly to stderr

### DIFF
--- a/bin/minigen.ml
+++ b/bin/minigen.ml
@@ -57,7 +57,7 @@ let get_type (t : STLC.term) : STLC.ty =
             , Infer.decode w ) ) )
   in
 
-  let _, env, nf = Solver.eval ~log:false Unif.Env.empty cst in
+  let env, nf = Solver.eval ~log:false Unif.Env.empty cst in
   match nf with
   | NRet v -> snd @@ v @@ Decode.decode env ()
   | NErr _ | NDo _ -> assert false

--- a/bin/minihell.ml
+++ b/bin/minihell.ml
@@ -75,19 +75,19 @@ let call_typer ~config (term : Untyped.term) =
     print_section "Generated constraint"
       (ConstraintPrinter.print_constraint cst);
 
-  let logs, result =
-    let logs, env, nf = Solver.eval ~log:config.log_solver Unif.Env.empty cst in
-    let result =
-      match nf with
-      | NRet v -> Ok (v (Decode.decode env ()))
-      | NErr e -> Error e
-      | NDo _ -> .
-    in
-    (logs, result)
+  let env, nf =
+    if config.log_solver then
+      prerr_endline "Constraint solving log:";
+    let p = Solver.eval ~log:config.log_solver Unif.Env.empty cst in
+    if config.log_solver then prerr_newline ();
+    p
   in
-
-  if config.log_solver then
-    print_section "Constraint solving log" PPrint.(separate hardline logs);
+  let result =
+    match nf with
+    | NRet v -> Ok (v (Decode.decode env ()))
+    | NErr e -> Error e
+    | NDo _ -> .
+  in
 
   result
 

--- a/src/Generator.ml
+++ b/src/Generator.ml
@@ -114,7 +114,7 @@ module Make (M : Utils.MonadPlus) = struct
      fun ~fuel env cstr ->
       if fuel = -1 then M.fail
       else
-        let _logs, env, nf = Solver.eval ~log:false env cstr in
+        let env, nf = Solver.eval ~log:false env cstr in
 
         match nf with
         | NRet v when fuel = 0 -> M.return @@ v (Decode.decode env ())

--- a/src/Solver.ml
+++ b/src/Solver.ml
@@ -19,21 +19,12 @@ module Make (T : Utils.Functor) = struct
   type log = PPrint.document list
 
   let make_logger c0 =
-    let logs = Queue.create () in
     let c0_erased = SatConstraint.erase c0 in
-
-    let add_to_log env =
-      let doc =
-        c0_erased
-        |> ConstraintSimplifier.simplify env
-        |> ConstraintPrinter.print_sat_constraint
-      in
-      Queue.add doc logs
-    in
-
-    let get_log () = logs |> Queue.to_seq |> List.of_seq in
-
-    (add_to_log, get_log)
+    fun env ->
+      c0_erased
+      |> ConstraintSimplifier.simplify env
+      |> ConstraintPrinter.print_sat_constraint
+      |> Utils.string_of_doc |> prerr_endline
 
   (** See [../README.md] ("High-level description") or [Solver.mli] for a
       description of normal constraints and our expectations regarding the
@@ -50,10 +41,9 @@ module Make (T : Utils.Functor) = struct
   let ndo t = NDo t
 
   let eval (type a e) ~log (unif_env : unif_env) (c0 : (a, e) Constraint.t) :
-    log * unif_env * (a, e) normal_constraint =
+    unif_env * (a, e) normal_constraint =
     (* We recommend calling the function [add_to_log] above
-         whenever you get an updated environment. Then call
-         [get_log] at the end to get a list of log message.
+         whenever you get an updated environment.
 
          $ dune exec -- minihell --log-solver foo.test
 
@@ -64,8 +54,8 @@ module Make (T : Utils.Functor) = struct
          (You can also tweak this code temporarily to print stuff on
          stderr right away if you need dirtier ways to debug.)
     *)
-    let add_to_log, get_log =
-      if log then make_logger c0 else (ignore, fun _ -> [])
+    let add_to_log =
+      if log then make_logger c0 else ignore
     in
 
     let exception Located of Utils.loc * exn * Printexc.raw_backtrace in
@@ -234,5 +224,5 @@ module Make (T : Utils.Functor) = struct
       Printf.eprintf "Error at %s" (MenhirLib.LexerUtil.range loc);
       Printexc.raise_with_backtrace exn bt
     | exception exn -> raise exn
-    | result -> (get_log (), !unif_env, result)
+    | result -> (!unif_env, result)
 end

--- a/src/Solver.mli
+++ b/src/Solver.mli
@@ -23,13 +23,13 @@ module Make (T : Utils.Functor) : sig
           operation [E[_] : ('a1, 'e1) Constraint.t -> ('a2, 'e2) Constraint.t]
       *)
 
-  (** If [~log:true] is passed in input, collect a list of intermediate steps
-      (obtained from the solver environment and the original constraint by
-      constraint simplification) as the constraint-solving progresses. Otherwise
-      the returned [log] will not be used and could be returned empty. *)
+  (** If [~log:true] is passed in input, print to stderr a list of
+      intermediate steps (obtained from the solver environment and the
+      original constraint by constraint simplification) as the
+      constraint-solving progresses. *)
   val eval :
        log:bool
     -> unif_env
     -> ('a, 'e) Constraint.t
-    -> log * unif_env * ('a, 'e) normal_constraint
+    -> unif_env * ('a, 'e) normal_constraint
 end

--- a/unit_tests/bug_in_simplifier.ml
+++ b/unit_tests/bug_in_simplifier.ml
@@ -7,6 +7,4 @@ let () =
     let b = Var.fresh "b" in
     Exist (a, None, Exist (b, None, Conj (Eq (a, b), Do MSeq.fail)))
   in
-  let logs, _env, _result = Solver.eval ~log:true Unif.Env.empty c in
-  PPrint.(separate hardline logs)
-  |> Utils.string_of_doc |> print_endline |> print_newline
+  ignore (Solver.eval ~log:true Unif.Env.empty c)


### PR DESCRIPTION
This makes it easier to interleave debug information, and we also see better debug output in the case where the solver raises an exception.